### PR TITLE
Build images only for amd64

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -35,28 +35,28 @@ jobs:
         
         - image: executor
           target: kaniko-executor
-          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+          platforms: linux/amd64
           image-name: executor
           tag: ${{ github.sha }}
           release-tag: latest
 
         - image: executor-debug
           target: kaniko-debug
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: linux/amd64
           image-name: executor
           tag: ${{ github.sha }}-debug
           release-tag: debug
 
         - image: executor-slim
           target: kaniko-slim
-          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+          platforms: linux/amd64
           image-name: executor
           tag: ${{ github.sha }}-slim
           release-tag: slim
 
         - image: warmer
           target: kaniko-warmer
-          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+          platforms: linux/amd64
           image-name: warmer
           tag: ${{ github.sha }}
           release-tag: latest


### PR DESCRIPTION
Pipeline failed on `main` with:
```
#2 [linux/ppc64le internal] load metadata for docker.io/library/debian:bullseye-slim
#2 ERROR: no match for platform in manifest: not found
```

We don't need it anyway so let's just get rid of it, along with everything except amd64.