### PR TITLE
Fix wrong image name

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -36,28 +36,28 @@ jobs:
         - image: executor
           target: kaniko-executor
           platforms: linux/amd64
-          image-name: executor
+          image-name: public.ecr.aws/x8w6c8k3/kaniko/executor
           tag: ${{ github.sha }}
           release-tag: latest
 
         - image: executor-debug
           target: kaniko-debug
           platforms: linux/amd64
-          image-name: executor
+          image-name: public.ecr.aws/x8w6c8k3/kaniko/executor
           tag: ${{ github.sha }}-debug
           release-tag: debug
 
         - image: executor-slim
           target: kaniko-slim
           platforms: linux/amd64
-          image-name: executor
+          image-name: public.ecr.aws/x8w6c8k3/kaniko/executor
           tag: ${{ github.sha }}-slim
           release-tag: slim
 
         - image: warmer
           target: kaniko-warmer
           platforms: linux/amd64
-          image-name: warmer
+          image-name: public.ecr.aws/x8w6c8k3/kaniko/warmer
           tag: ${{ github.sha }}
           release-tag: latest
 
@@ -98,7 +98,7 @@ jobs:
         file: ./deploy/Dockerfile
         platforms: ${{ steps.platforms.outputs.platforms }}
         push: ${{ github.event_name != 'pull_request' }} # Only push if not a PR.
-        tags: ${{ steps.login-ecr-public.outputs.registry }}/${{ matrix.image-name }}:${{ matrix.tag }}
+        tags: ${{ matrix.image-name }}:${{ matrix.tag }}
         no-cache-filters: certs
         # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache
         cache-from: type=gha
@@ -114,15 +114,15 @@ jobs:
         tag=${GITHUB_REF/refs\/tags\//}
 
         # Tag :latest, :debug, :slim
-        crane cp ${{ steps.login-ecr-public.outputs.registry }}/${{ matrix.image-name }}@${{ steps.build-and-push.outputs.digest }} \
-            ${{ steps.login-ecr-public.outputs.registry }}/${{ matrix.image-name }}:${{ matrix.release-tag }}
+        crane cp ${{ matrix.image-name }}@${{ steps.build-and-push.outputs.digest }} \
+            ${{ matrix.image-name }}:${{ matrix.release-tag }}
 
         if [[ "${{ matrix.release-tag }}" == "latest" ]]; then
           # Tag :latest images as :v1.X.Y
-          crane cp ${{ steps.login-ecr-public.outputs.registry }}/${{ matrix.image-name }}@${{ steps.build-and-push.outputs.digest }} \
-              ${{ steps.login-ecr-public.outputs.registry }}/${{ matrix.image-name }}:${tag}
+          crane cp ${{ matrix.image-name }}@${{ steps.build-and-push.outputs.digest }} \
+              ${{ matrix.image-name }}:${tag}
         else
           # Or tag :v1.X.Y-debug and :v1.X.Y-slim
-          crane cp ${{ steps.login-ecr-public.outputs.registry }}/${{ matrix.image-name }}@${{ steps.build-and-push.outputs.digest }} \
-              ${{ steps.login-ecr-public.outputs.registry }}/${{ matrix.image-name }}:${tag}-${{ matrix.release-tag }}
+          crane cp ${{ matrix.image-name }}@${{ steps.build-and-push.outputs.digest }} \
+              ${{ matrix.image-name }}:${tag}-${{ matrix.release-tag }}
         fi


### PR DESCRIPTION
The full image name is `public.ecr.aws/executor` instead of `public.ecr.aws/x8w6c8k3/kaniko/executor` currently. 